### PR TITLE
Generate better XmlDocs

### DIFF
--- a/src/Lumina.Excel.Generator/GeneratorUtils.cs
+++ b/src/Lumina.Excel.Generator/GeneratorUtils.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using System;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Xml;
@@ -18,10 +19,25 @@ internal static class GeneratorUtils
     public static string CreateDocstring(string text)
     {
         var sb = new StringBuilder();
-        using (var writer = XmlWriter.Create(sb, new XmlWriterSettings() { OmitXmlDeclaration = true, NewLineChars = " " })) 
+        using (var writer = XmlWriter.Create(sb, new XmlWriterSettings() { OmitXmlDeclaration = true })) 
         {
             writer.WriteStartElement("summary");
-            writer.WriteString(text);
+            writer.WriteWhitespace("\n");
+            writer.WriteString("/// ");
+            var lines = text.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (i > 0)
+                {
+                    writer.WriteElementString("br", string.Empty);
+                    writer.WriteWhitespace("\n");
+                    writer.WriteString("/// ");
+                }
+                writer.WriteString(line.Trim());
+            }
+            writer.WriteWhitespace("\n");
+            writer.WriteString("/// ");
             writer.WriteEndElement();
         }
         return sb.ToString();


### PR DESCRIPTION
I noticed that multiline comments like on [`Item.FilterGroup`](https://github.com/xivdev/EXDSchema/blob/5829bcd9f43a9d2016c07ab88bec67d970637216/Item.yml#L107) are generated as single line, which makes it hard to read:

> <img width="1973" height="221" alt="Before" src="https://github.com/user-attachments/assets/6f80bb1b-a148-47b8-bccb-55cba99d1993" />

With this PR, multiline comments are generated properly with `<br/>` tags:

> <img width="578" height="1185" alt="After" src="https://github.com/user-attachments/assets/20e5755f-5cf4-4b32-b4cb-097d71d22510" />

Another example, [`ZoneSharedGroup.RequirementType`](https://github.com/xivdev/EXDSchema/blob/5829bcd9f43a9d2016c07ab88bec67d970637216/ZoneSharedGroup.yml#L16):

> <img width="588" height="159" alt="dtpfERgicf" src="https://github.com/user-attachments/assets/fc99a1e4-32e8-4f8b-be30-ecb0785b0ac8" />

Single line comments, like on [`ChocoboTaxi.TimeRequired`](https://github.com/xivdev/EXDSchema/blob/5829bcd9f43a9d2016c07ab88bec67d970637216/ChocoboTaxi.yml#L10), are generated correctly too, like this:

> <img width="492" height="91" alt="gnsbiC2JK3" src="https://github.com/user-attachments/assets/49e8fa71-7bff-4916-a843-373415449ae3" />