### PR TITLE
Expose ExcelPage and row offset

### DIFF
--- a/src/Lumina.Excel.Generator/SourceConstants.cs
+++ b/src/Lumina.Excel.Generator/SourceConstants.cs
@@ -49,6 +49,8 @@ using System.CodeDom.Compiler;
         sb.AppendLine("{");
         using (sb.IndentScope())
         {
+            sb.AppendLine($"public {globalize("Lumina.Excel.ExcelPage")} ExcelPage => page;");
+            sb.AppendLine($"public uint RowOffset => offset;");
             sb.AppendLine("public uint RowId => row;");
             if (converter.HasSubrows)
                 sb.AppendLine("public ushort SubrowId => subrow;");


### PR DESCRIPTION
Some sheets in EXDSchema have separate columns for data that should probably be in an array, like [ClassJobCategory](https://github.com/xivdev/EXDSchema/blob/latest/ClassJobCategory.yml), [EquipSlotCategory](https://github.com/xivdev/EXDSchema/blob/latest/EquipSlotCategory.yml), [RecipeLookup](https://github.com/xivdev/EXDSchema/blob/latest/RecipeLookup.yml) or [MirageStoreSetItem](https://github.com/xivdev/EXDSchema/blob/latest/MirageStoreSetItem.yml), but I don't necessarily want them to get rid of those column names, or have a whole discussion about how EXDSchema should adapt to this.

So far I've made my own structs that contained those arrays, but it would be much nicer if I could write extension properties instead, given that Dalamud is switching to .NET 10 with 7.4.
For that I need access to the `page` and `offset` attributes from the ctor.
This PR exposes those as `ExcelPage` and `RowOffset` properties (to avoid name conflicts).

I don't know if this is a good idea or not, probably not, but it's also not much to ask for, is it? :}