### PR TITLE
Source generation fixes

### DIFF
--- a/src/Lumina.Excel.Generator/SchemaGenerator.cs
+++ b/src/Lumina.Excel.Generator/SchemaGenerator.cs
@@ -39,7 +39,7 @@ public class SchemaGenerator : IIncrementalGenerator
                     throw new InvalidOperationException($"SchemaPath {schemaDir.FullName} does not exist");
             }
 
-            if (experimentalSchemaPath != null)
+            if (!string.IsNullOrWhiteSpace(experimentalSchemaPath))
             {
                 var schemaDir = new DirectoryInfo(experimentalSchemaPath);
                 if (!schemaDir.Exists)

--- a/src/Lumina.Excel.Generator/SchemaGenerator.cs
+++ b/src/Lumina.Excel.Generator/SchemaGenerator.cs
@@ -100,7 +100,7 @@ public class SchemaGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(options, (ctx, opts) =>
         {
             if (opts.UseSchemaAttribute)
-                ctx.AddSource("SheetSchemaAttribute.g.cs", SourceConstants.CreateAttributeSource("SheetSchema", false));
+                ctx.AddSource("SheetSchemaAttribute.generated.cs", SourceConstants.CreateAttributeSource("SheetSchema", false));
         });
 
         var fqmn = $"{SourceConstants.GeneratedNamespace}.SheetSchemaAttribute";
@@ -170,7 +170,7 @@ public class SchemaGenerator : IIncrementalGenerator
             var source = SourceConstants.CreateSchemaSource(symbol.ContainingNamespace.IsGlobalNamespace ? null : symbol.ContainingNamespace.ToString(), symbol.Name, true, options.UseFileScopedNamespace, false, converter);
             if (options.DebugFiles)
                 context.Debug($"{Convert.ToBase64String(Encoding.UTF8.GetBytes(source.ToString()))}");
-            context.AddSource($"{symbol.Name}.g.cs", source);
+            context.AddSource($"{symbol.Name}.generated.cs", source);
         }
         catch (Exception e)
         {
@@ -214,7 +214,7 @@ public class SchemaGenerator : IIncrementalGenerator
                 var name = useExperimentalSchema ? $"{sheet.Name}.Experimental" : sheet.Name;
                 if (options.DebugFiles)
                     context.Debug($"{name} -> {Convert.ToBase64String(Encoding.UTF8.GetBytes(source.ToString()))}");
-                context.AddSource($"{name}.g.cs", source);
+                context.AddSource($"{name}.generated.cs", source);
             }
             catch (Exception e)
             {

--- a/src/Lumina.Excel.Generator/SourceConstants.cs
+++ b/src/Lumina.Excel.Generator/SourceConstants.cs
@@ -78,7 +78,7 @@ using System.CodeDom.Compiler;
         if (!string.IsNullOrEmpty(targetNamespace))
             ret = ScopeNamespace(useFileScopedNamespace, converter.IndentString, targetNamespace!, ret);
 
-        ret = $"{converter.TypeGlobalizer.GetUsings()}\n{ret}";
+        ret = $"#pragma warning disable CS9113\n{converter.TypeGlobalizer.GetUsings()}\n{ret}";
 
         return SourceText.From(ret.Trim(), Encoding.UTF8);
     }


### PR DESCRIPTION
This PR addresses some issues when the generator is used directly.

1) Without defining `ExperimentalSchemaPath` in the .csproj, the following error is thrown:

> CSC : warning CS8785: Generator 'SchemaGenerator' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'ArgumentException' with message 'The path is empty. (Parameter 'path')'.

Checking with `!string.IsNullOrWhiteSpace` instead of a simple null check fixes this.

2) I wanted to add `// <auto-generated />` to the generated source code, as I've seen this a couple times before and I think this has something to do with analysis and refactoring, but then I found on https://learn.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=visualstudio#configure-generated-code that files ending with `.generated.cs` are also considered generated code, so let's use that?!?

3) Lastly, a couple sheets are throwing this warning:

> obj\x64\Debug\Lumina.Excel.Generator\Lumina.Excel.Generator.SchemaGenerator\BankaCraftWorksSupply.generated.cs(18,60,18,72): warning CS9113: Parameter 'parentOffset' is unread.

So I suppressed it in the generated code. Not sure what else to do.

4) Made it so the experimental schema uses column definitions (.github/columns.yml) from the experimental schema path.